### PR TITLE
Make the leaderboards page mobile friendly

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default async function RootLayout({
         )}
       >
         <StreamersProvider players={streamers}>
-          <div className="min-h-screen flex">
+          <div className="min-h-screen flex flex-wrap">
             <Sidebar />
             {children}
           </div>

--- a/src/app/leaderboard/Leaderboard.tsx
+++ b/src/app/leaderboard/Leaderboard.tsx
@@ -19,7 +19,7 @@ export const LeaderboardPage = (props: PageProps) => {
   const { players } = usePlayers();
 
   return (
-    <div className="flex-1 grid grid-cols-2 place-items-center items-center justify-center">
+    <div className="flex-1 mx-1 grid grid-cols-1 xl:grid-cols-2 gap-y-10 place-items-center items-center justify-center min-w-[400px]">
       <LiveLeaderboard players={players} />
       <GlobalLeaderboard leaderboard={props.leaderboard} />
     </div>
@@ -66,7 +66,7 @@ const LiveLeaderboard = ({ players }: { players: PlayerData[] }) => {
   }, [onlyStreamers, players]);
 
   return (
-    <div>
+    <div className="w-full sm:w-[400px]">
       <Leaderboard title="Live Leaderboard">
         {filtered
           .filter((s) => s.currentHeight > 0)
@@ -104,7 +104,7 @@ type LeaderboardProps = {
 
 const Leaderboard = ({ children, title }: LeaderboardProps) => {
   return (
-    <div className="flex flex-col justify-center w-[400px] max-h-[80vh] overflow-y-auto">
+    <div className="flex flex-col justify-center w-full sm:w-[400px] max-h-[80vh] overflow-y-auto">
       <h2 className="text-center mb-4 text-lg font-bold text-primary">
         {title}
       </h2>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -27,7 +27,7 @@ export const Sidebar = () => {
   }, [players]);
 
   return (
-    <div className="px-4 py-6 flex flex-col gap-4 w-[300px] max-h-screen">
+    <div className="px-4 py-6 flex flex-col gap-4 w-full sm:w-[300px] max-h-screen">
       <div className="flex justify-center">
         <h1 className="text-6xl font-black tracking-tighter leading-[0.8em] text-center scale-x-120 text-primary">
           DEEP SLIP


### PR DESCRIPTION
While trying to check the current progress on my phone, i realized that the leaderboards page is not mobile friendly, as all 3 columns are overlapping (the menu on the left and the two leaderboards)

I added some more style classes to make the page as responsive as possible. while it looks kinda weird in some inbetween resolutions due to the fixed width of some elements, it should now work in the majority of cases

If you have any improvement requests or want me to minimize the changes, let me know and i can update the PR